### PR TITLE
fetchers: use semver.coerce instead of semver.parse

### DIFF
--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -338,7 +338,7 @@ export async function fetchVersion(
   }
 
   const validVersions = versions.flatMap(({ main, app }) => {
-    const parsedVersion = semver.parse(main);
+    const parsedVersion = semver.coerce(main);
     if (parsedVersion === null) {
       return [];
     }


### PR DESCRIPTION
Fixes version fetching for projects like acme-dns, which use tags like "v1.0", which would otherwise show "v0.7.2" as the latest version.

node-semver expects three version parts, and fails to parse if there are fewer.

    > semver.parse("1.0")?.version;
    undefined

    > semver.coerce("1.0")?.version;
    '1.0.0'