### PR TITLE
Non semver friendly

### DIFF
--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -371,6 +371,14 @@ export async function fetchVersion(
     throw new Error("No valid versions");
   }
 
+  validVersions.sort((a, b) => {
+    if (a.semantic !== null && b.semantic !== null) {
+      return semver.rcompare(a.semantic, b.semantic);
+    } else {
+      return -a.main.localeCompare(b.main);
+    }
+  });
+
   const latest = validVersions[0];
   const version = spec.versionSpec
     ? validVersions.find(({ semantic }) =>

--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -122,7 +122,8 @@ export class Version {
   public readonly prerelease: boolean;
 
   constructor(main: string, app?: string, prerelease?: boolean) {
-    this.semantic = semver.coerce(main);
+    // coerce does not include prerelease tags so we try strict parsing first and then coerce if that fails
+    this.semantic = semver.parse(main) ?? semver.coerce(main);
     this.main = cleanVersion(main);
     this.app = app && cleanVersion(app);
     this.prerelease = prerelease === undefined


### PR DESCRIPTION
Preserve the original version names when fetching from upstream. Since we only need semver fields for filtering / matching we just keep a separate object for it.