### PR TITLE
flake: add aarch64-darwin; support nix run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,32 @@
 {
   description = "Version checker";
 
-  outputs = { self, nixpkgs }: {
+  outputs = { self, nixpkgs }:
+    let
+      supportedPlatforms = [ "x86_64-linux" "aarch64-darwin" ];
+      inherit (nixpkgs) lib;
+    in {
+      devShells = lib.genAttrs supportedPlatforms (system: {
+        default = with nixpkgs.legacyPackages."${system}"; mkShell {
+          packages = [ deno sqlite ];
+        };
+      });
 
-    devShell.x86_64-linux = with nixpkgs.legacyPackages.x86_64-linux; mkShell {
-      packages = [ deno sqlite ];
+      packages = lib.genAttrs supportedPlatforms (system: {
+        default =
+          with nixpkgs.legacyPackages."${system}";
+          runCommand "versioncheck" {
+            nativeBuildInputs = [ makeWrapper ];
+          } ''
+            mkdir $out $out/{bin,lib}
+            cp -vr ${./src}/*        $out/lib/
+            cp -v  ${./versioncheck} $out/bin/versioncheck
+
+            substituteInPlace $out/bin/versioncheck \
+              --replace "src/index.ts" "$out/lib/index.ts"
+
+            wrapProgram $out/bin/versioncheck --prefix PATH : ${lib.makeBinPath [ deno ]}
+          '';
+      });
     };
-
-  };
 }


### PR DESCRIPTION
I want to be able to `nix run github:iknow/versioncheck` without having to compose a more complex nix shell command. It's a bit of a lie, since deno will still fetch the dependencies, but it makes it slightly more convenient.