### PR TITLE
Fetch nixpkg hashes as version

### DIFF
--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -1,6 +1,6 @@
 import { dom, YAML, z } from "./deps.ts";
 import { Cache } from "./cache.ts";
-import { applyRegexp, makeVersion, Version } from "./version.ts";
+import { applyRegexp, makeVersion, Version, NixpkgsVersion } from "./version.ts";
 
 const BaseFetchSchema = z.object({
   versionSpec: z.string().optional(),
@@ -319,7 +319,7 @@ async function fetchNixpkgs(
     return match[1];
   });
 
-  return [makeVersion(version)];
+  return [new NixpkgsVersion(version)];
 }
 
 function assertNever(): never {

--- a/src/version.ts
+++ b/src/version.ts
@@ -10,16 +10,13 @@ export interface Version {
 }
 
 const COMMIT_REGEX = /^[0-9a-f]{40}$/;
-
-// nix encodes hashes in base32 with an unusual set of characters (without E O U T).
-// https://github.com/NixOS/nix/blob/2ef99cd10489929a755831251c3fad8f3df2faeb/src/libutil/hash.cc#L85
-const NIX_HASH_REGEX = /^[0-9abcdfghijklmnpqrsvwxyz]{52}$/;
+const NIXPKGS_REGEX = /^nixpkgs-[\w\.]+\.[\da-f]+$/;
 
 export function makeVersion(main: string, app?: string, prerelease?: boolean) {
   if (COMMIT_REGEX.test(main)) {
     return new CommitVersion(main);
-  } else if (NIX_HASH_REGEX.test(main)) {
-    return new NixHashVersion(main);
+  } else if (NIXPKGS_REGEX.test(main)) {
+    return new NixpkgsVersion(main);
   } else {
     return new SemanticVersion(main, app, prerelease);
   }
@@ -41,7 +38,7 @@ export class CommitVersion implements Version {
   }
 }
 
-export class NixHashVersion implements Version {
+export class NixpkgsVersion implements Version {
   constructor(public readonly main: string) { }
 
   public get prerelease() {

--- a/versioncheck
+++ b/versioncheck
@@ -3,7 +3,7 @@ exec deno run \
   --no-check \
   --allow-net \
   --allow-read \
-  --allow-run=git \
+  --allow-run=git,nix-prefetch-url \
   --allow-write=cache.db,cache.db-journal \
   --allow-env=VERSIONCHECK_CONFIG,VERSIONCHECK_PATHS,GITHUB_TOKEN \
   src/index.ts "$@"

--- a/versioncheck
+++ b/versioncheck
@@ -3,7 +3,7 @@ exec deno run \
   --no-check \
   --allow-net \
   --allow-read \
-  --allow-run=git,nix-prefetch-url \
+  --allow-run=git \
   --allow-write=cache.db,cache.db-journal \
   --allow-env=VERSIONCHECK_CONFIG,VERSIONCHECK_PATHS,GITHUB_TOKEN \
   src/index.ts "$@"


### PR DESCRIPTION
Refs iknow/issues#5243
This PR adds new fetcher type "nixpkgs" which will follows the same method of [generate-pin.rb](https://github.com/iknow/eikaiwa_content_frontend/blob/f2407e15b92d53a6bbc83f71e2ed00c10583ac64/nix/generate-pin.rb) and finds the hash of `nixexprs.tar.xz` as the version.

Usage Example:
```yaml
pinned-nixpkgs:
  upstream:
    type: nixpkgs
    channel: nixpkgs-unstable
  usages:
    replace-dev-server:
      type: file
      source: https://github.com/iknow/replace-dev-server/blob/HEAD/nix/pinned-nixpkgs.json
      parser:
        type: yaml #Yes, JSON is also a valid YAML
        query: "url"
        regexp: "https://releases.nixos.org/nixpkgs/([^/]+)/nixexprs.tar.xz"
```